### PR TITLE
Bugfix

### DIFF
--- a/alggago.rb
+++ b/alggago.rb
@@ -126,7 +126,7 @@ class Alggago < Gosu::Window
     @players.each do |player|
       player.update
       player.stones.each do |stone| 
-        @can_throw = false if (stone.body.w != 0) or (stone.body.v.x != 0) or (stone.body.v.y != 0) 
+        @can_throw = false if (stone.body.v.x != 0) or (stone.body.v.y != 0) 
         if stone.should_delete 
           @space.remove_body(stone.body)
           @space.remove_shape(stone.shape)
@@ -221,8 +221,7 @@ class Alggago < Gosu::Window
   end
 
   def button_down(id) 
-    can_throw = true
-    if can_throw
+    if @can_throw
       case id 
       when Gosu::KbR 
         restart
@@ -246,6 +245,11 @@ class Alggago < Gosu::Window
   def button_up(id)
     case id 
     when Gosu::MsLeft
+	  @players.each do |player|
+	    player.stones.each do |s|
+		  s.body.w =0
+		end
+	  end
       if !@selected_stone.nil?
         x_diff = mouse_x - (@selected_stone.body.p.x + STONE_DIAMETER/2.0)
         y_diff = mouse_y - (@selected_stone.body.p.y + STONE_DIAMETER/2.0)

--- a/alggago.rb
+++ b/alggago.rb
@@ -245,12 +245,12 @@ class Alggago < Gosu::Window
   def button_up(id)
     case id 
     when Gosu::MsLeft
-	  @players.each do |player|
-	    player.stones.each do |s|
-		  s.body.w =0
-		end
-	  end
       if !@selected_stone.nil?
+		@players.each do |player|
+		  player.stones.each do |s|
+		    s.body.w =0
+		  end
+		end
         x_diff = mouse_x - (@selected_stone.body.p.x + STONE_DIAMETER/2.0)
         y_diff = mouse_y - (@selected_stone.body.p.y + STONE_DIAMETER/2.0)
 


### PR DESCRIPTION
돌이 이중 중에 마우스로 돌을 잡으면 돌이 정지 됩니다.

그래서 함수 button_down에 can_throw = true  를 삭제 후
224번 줄을 if @can_throw  로 변경했습니다.

그리고 돌이 너무 오래 회전하는 것을 막기 위해 라인 129에 stone.body.w !=0 조건을 제거 했습니다.

또한 동시에 회전하는 상태로 출발 하면, 결과에 영향을 줄 수 있기 때문에 돌을 누르면, 회전 값을 전부 0으로 변환하는 코드를 아래와 같이 넣었습니다.

249         @players.each do |player|
250           player.stones.each do |s|
251             s.body.w =0
252           end
253         end

합당여부 검토후 수정 요청 드립니다.  
강의 정말 재미나게 잘 들었습니다. 항상 감사합니다.^^ㅎ
